### PR TITLE
25w19a+ version support

### DIFF
--- a/assets/minecraft/shaders/core/rendertype_text.fsh
+++ b/assets/minecraft/shaders/core/rendertype_text.fsh
@@ -1,11 +1,12 @@
 #version 150
 
-#moj_import <fog.glsl>
+#moj_import <minecraft:fog.glsl>
 #moj_import <minecraft:dynamictransforms.glsl>
 
 uniform sampler2D Sampler0;
 
-in float vertexDistance;
+in float sphericalVertexDistance;
+in float cylindricalVertexDistance;
 in vec4 vertexColor;
 in vec2 texCoord0;
 
@@ -16,18 +17,11 @@ void main() {
     if (color.a < 0.1) {
         discard;
     }
-    
+
     if (color.r > 0.2479 && color.r < 0.2481
         && color.g > 0.2479 && color.g < 0.2481
         && color.b > 0.2479 && color.b < 0.2481) {
         color = vec4(0.6667, 0.6667, 0.6667, 1.0);
     }
-    
-    vec3 pos = vec3(0.0, 0.0, vertexDistance);
-    float sphericalDist = fog_spherical_distance(pos);
-    float cylindricalDist = fog_cylindrical_distance(pos);
-    
-    fragColor = apply_fog(color, sphericalDist, cylindricalDist, 
-                        FogEnvironmentalStart, FogEnvironmentalEnd,
-                        FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
+    fragColor = apply_fog(color, sphericalVertexDistance, cylindricalVertexDistance, FogEnvironmentalStart, FogEnvironmentalEnd, FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_text.fsh
+++ b/assets/minecraft/shaders/core/rendertype_text.fsh
@@ -1,13 +1,9 @@
 #version 150
 
 #moj_import <fog.glsl>
+#moj_import <minecraft:dynamictransforms.glsl>
 
 uniform sampler2D Sampler0;
-
-uniform vec4 ColorModulator;
-uniform float FogStart;
-uniform float FogEnd;
-uniform vec4 FogColor;
 
 in float vertexDistance;
 in vec4 vertexColor;
@@ -20,12 +16,18 @@ void main() {
     if (color.a < 0.1) {
         discard;
     }
-	
-	if (color.r > 0.2479 && color.r < 0.2481
+    
+    if (color.r > 0.2479 && color.r < 0.2481
         && color.g > 0.2479 && color.g < 0.2481
         && color.b > 0.2479 && color.b < 0.2481) {
         color = vec4(0.6667, 0.6667, 0.6667, 1.0);
     }
-	
-    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    
+    vec3 pos = vec3(0.0, 0.0, vertexDistance);
+    float sphericalDist = fog_spherical_distance(pos);
+    float cylindricalDist = fog_cylindrical_distance(pos);
+    
+    fragColor = apply_fog(color, sphericalDist, cylindricalDist, 
+                        FogEnvironmentalStart, FogEnvironmentalEnd,
+                        FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_text_intensity.fsh
+++ b/assets/minecraft/shaders/core/rendertype_text_intensity.fsh
@@ -1,11 +1,12 @@
 #version 150
 
-#moj_import <fog.glsl>
+#moj_import <minecraft:fog.glsl>
 #moj_import <minecraft:dynamictransforms.glsl>
 
 uniform sampler2D Sampler0;
 
-in float vertexDistance;
+in float sphericalVertexDistance;
+in float cylindricalVertexDistance;
 in vec4 vertexColor;
 in vec2 texCoord0;
 
@@ -16,18 +17,11 @@ void main() {
     if (color.a < 0.1) {
         discard;
     }
-    
+
     if (color.r > 0.2479 && color.r < 0.2481
         && color.g > 0.2479 && color.g < 0.2481
         && color.b > 0.2479 && color.b < 0.2481) {
         color = vec4(0.6667, 0.6667, 0.6667, 1.0);
     }
-    
-    vec3 pos = vec3(0.0, 0.0, vertexDistance);
-    float sphericalDist = fog_spherical_distance(pos);
-    float cylindricalDist = fog_cylindrical_distance(pos);
-    
-    fragColor = apply_fog(color, sphericalDist, cylindricalDist, 
-                        FogEnvironmentalStart, FogEnvironmentalEnd,
-                        FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
+    fragColor = apply_fog(color, sphericalVertexDistance, cylindricalVertexDistance, FogEnvironmentalStart, FogEnvironmentalEnd, FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
 }

--- a/assets/minecraft/shaders/core/rendertype_text_intensity.fsh
+++ b/assets/minecraft/shaders/core/rendertype_text_intensity.fsh
@@ -1,13 +1,9 @@
 #version 150
 
 #moj_import <fog.glsl>
+#moj_import <minecraft:dynamictransforms.glsl>
 
 uniform sampler2D Sampler0;
-
-uniform vec4 ColorModulator;
-uniform float FogStart;
-uniform float FogEnd;
-uniform vec4 FogColor;
 
 in float vertexDistance;
 in vec4 vertexColor;
@@ -20,12 +16,18 @@ void main() {
     if (color.a < 0.1) {
         discard;
     }
-	
-	if (color.r > 0.2479 && color.r < 0.2481
+    
+    if (color.r > 0.2479 && color.r < 0.2481
         && color.g > 0.2479 && color.g < 0.2481
         && color.b > 0.2479 && color.b < 0.2481) {
         color = vec4(0.6667, 0.6667, 0.6667, 1.0);
     }
-	
-    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    
+    vec3 pos = vec3(0.0, 0.0, vertexDistance);
+    float sphericalDist = fog_spherical_distance(pos);
+    float cylindricalDist = fog_cylindrical_distance(pos);
+    
+    fragColor = apply_fog(color, sphericalDist, cylindricalDist, 
+                        FogEnvironmentalStart, FogEnvironmentalEnd,
+                        FogRenderDistanceStart, FogRenderDistanceEnd, FogColor);
 }


### PR DESCRIPTION
Fixes #237
1.21.6 snapshots have changed a lot in the functionality of the core shaders, especially for shaders using fog.glsl, hence the fix